### PR TITLE
added de.NBI training announcement @ GMDS 2018

### DIFF
--- a/_events/2018-09-04-GMDS2018.md
+++ b/_events/2018-09-04-GMDS2018.md
@@ -19,5 +19,5 @@ supporters:
 - emed
 ---
 
-The registration for the Galaxy training on RNA-Seq analyses and clinical applications (September 2018) is open! For the program and registration, please check [this link](https://gmds.de/aktuelles-termine/tagungen-2018-willkommen/anmeldung-zur-tagung/)
+The registration for the Galaxy training on RNA-Seq analyses and clinical applications (September 2018) is open! For the program and registration, please check the [English](http://www.denbi.de/22-training-cat/training-courses/599-rna-seq-data-analysis-with-galaxy-for-clinical-applications-gmds-2018) and [German](https://gmds.de/aktuelles-termine/tagungen-2018-willkommen/anmeldung-zur-tagung/) announcements.
 

--- a/_events/2018-09-04-GMDS2018.md
+++ b/_events/2018-09-04-GMDS2018.md
@@ -1,0 +1,23 @@
+---
+site: main
+tags: [training]
+title: RNA-Seq data analysis with Galaxy for clinical applications
+starts: 2018-09-04
+ends: 2018-09-04
+organiser:
+  name: Prof. Dr. Birgit Babitsch
+  email: gmds2018@hs-osnabrueck.de
+location:
+  name: Universität Osnabrück
+  street: Barbarastraße 21 (SL-Gebäude)
+  postal: 49076 Osnabrück
+  city: Osnabrück
+  region: Westfalen
+  country: Germany
+supporters:
+- denbi
+- emed
+---
+
+The registration for the Galaxy training on RNA-Seq analyses and clinical applications (September 2018) is open! For the program and registration, please check [this link](https://gmds.de/aktuelles-termine/tagungen-2018-willkommen/anmeldung-zur-tagung/)
+


### PR DESCRIPTION
Added the training announcement at GMDS 2018 (Osnabrück).
- since it's the GMDS organisation team that takes care of the registration procedures, I pointed the registration link to the GMDS webpage, instead of the de.NBI [announcement](http://www.denbi.de/22-training-cat/training-courses/599-rna-seq-data-analysis-with-galaxy-for-clinical-applications-gmds-2018)
- the `emed` supporter refers to the German [e:Med Systems Medicine Network](http://www.sys-med.de/en/)