### PR TITLE
Add post about GCC training nomination

### DIFF
--- a/_posts/2018-12-03-gcc-training-nomination.md
+++ b/_posts/2018-12-03-gcc-training-nomination.md
@@ -1,0 +1,8 @@
+---
+site: freiburg
+title: 'Nominate a training for the 2019 Galaxy Community Conference (GCC2019)'
+external: https://galaxyproject.org/news/2018-12-gcc2019-training-nomination/
+tags: [training]
+---
+
+The 2019 Galaxy Community Conference (GCC2019) will be held in be held in Freiburg, Germany, 1-6 July. The training topics that are offered are determined by the community so [BY YOU](https://docs.google.com/forms/d/1fBPjEmw7Td52rhBnC0SvflnQCD7Ue5IMJ9RkM0SjnYg/)!


### PR DESCRIPTION
Linking to the Hub post: https://galaxyproject.org/news/2018-12-gcc2019-training-nomination/