### PR TITLE
Event for Gallantries RNA-seq workshop in June

### DIFF
--- a/_events/2019-05-14-gallantries-ws.md
+++ b/_events/2019-05-14-gallantries-ws.md
@@ -1,0 +1,16 @@
+---
+site: freiburg
+tags: [training]
+title: "RNA-seq workshop for beginners: from sequences to visualization using Galaxy"
+starts: 2019-06-11
+ends: 2019-06-12
+organiser:
+  name: Gallantries team
+  email: berenice.batut@gmail.com
+external: https://galaxy-carpentries.github.io/gallantries/event/2019-03-25-first-galantries-workshop/
+supporters:
+ - elixir
+ - denbi
+---
+
+The Gallantries team is offering its first RNA-seq workshop for beginners on June, 11-12th. This workshop will be delivered simultaneously at two locations across Europe (Rotterdam, NL and Freiburg, DE). It will cover: Galaxy introduction, Introduction to High-Throughput Sequencing and Quality Control,     Reference-based RNA-seq data analysis.


### PR DESCRIPTION
This PR adds an event for the RNA-seq worskhop run nsimultaneously in Freiburg and Rotterdam next month