### PR TITLE
[WIP] Testing subdomain as a 'member site'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -112,6 +112,14 @@ team_sites:
       url: "https://galaxy.pasteur.fr/"
       galaxy_server: "https://galaxy.pasteur.fr/"
       blurb: ""
+    annotation:
+      name: Genome Annotation
+      subdomain: true
+      url: /annotation/
+      private_news: true
+      url: "https://annotation.usegalaxy.eu/"
+      galaxy_server: "https://annotation.usegalaxy.eu/"
+      blurb: ""
 
 header_links:
     main:
@@ -163,6 +171,15 @@ header_links:
           url: /pasteur/people
         - name: Publications
           url: /pasteur/publications
+    annotation:
+        - name: News
+          url: /annotation/news
+        - name: Events
+          url: /annotation/events
+        - name: People
+          url: /annotation/people
+        - name: Publications
+          url: /annotation/publications
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list

--- a/_data/people.yml
+++ b/_data/people.yml
@@ -192,3 +192,26 @@ erasmusmc:
         email: s.horsman@erasmusmc.nl
         phone: +31(0) 70 32460
         location: Ee-1579
+
+annotation:
+    erasche:
+        name: Helena Rasche
+        title: B.Sc. Biochem., Technician
+        email: hxr@informatik.uni-freiburg.de
+        phone: +49(0) 761 - 203 54128
+        location: "Build.: 079, Room: -1005a"
+        location_link: "https://goo.gl/maps/zEL3g3KVE8Q2"
+        gitter: erasche
+        orcid: 0000-0001-9760-8992
+        galaxyadmin: true
+
+    abretaud:
+        name: Anthony Bretaudeau
+        gitter: abretaud
+        bio: BIPAA/GenOuest
+
+    nathandunn:
+        name: Nathan Dunn
+        gitter: nathandunn
+        location: Oregon, United States
+        bio: Lawrence Berkeley National Lab

--- a/_events/2019-05-13-Westerdijk.md
+++ b/_events/2019-05-13-Westerdijk.md
@@ -1,0 +1,24 @@
+---
+site: annotation
+tags: [training]
+title: "Galaxy Workshop @ Fungal Biodiversity Institute Utrecht"
+starts: 2019-05-13
+ends: 2019-05-16
+organiser:
+  name: Westerdijk Fungal Biodiversity Institute
+  email:
+location:
+  name: Westerdijk Fungal Biodiversity Institute
+  street: Uppsalalaan 8
+  postal: 3584CT
+  city: Utrecht
+  country: The Netherlands
+supporters:
+---
+
+We will cover:
+
+- Galaxy
+- QC & Mapping
+- Genome Annotation with Maker
+- 16S Metagenomics with Mothur

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -42,9 +42,19 @@
              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="true">Member Sites <span class="caret"></span></a>
              <ul class="dropdown-menu">
               {% for path in site.team_sites %}
+              {% unless path[1].subdomain %}
                 <li>
                   <a class="page-link" href="/{{ path[0] }}/">{{ path[1].name | escape }}</a>
                 </li>
+              {% endunless %}
+              {% endfor %}
+                <li class="dropdown-header">Subdomains</li>
+              {% for path in site.team_sites %}
+              {% if path[1].subdomain %}
+                <li>
+                  <a class="page-link" href="/{{ path[0] }}/">{{ path[1].name | escape }}</a>
+                </li>
+              {% endif %}
               {% endfor %}
              </ul>
            </li>

--- a/_includes/home_news_events.html
+++ b/_includes/home_news_events.html
@@ -1,5 +1,8 @@
 {% assign page_dir = page.dir | split:'/' %}
 {% assign key = page_dir[1] | default: page.site  %}
+{% if include.key %}
+  {% assign key=include.key %}
+{% endif %}
 {% assign key_length = key | size %}
 
 <div class="row">

--- a/_posts/2019-07-22-ismb.md
+++ b/_posts/2019-07-22-ismb.md
@@ -1,0 +1,13 @@
+---
+site: annotation
+title: GGA @ ISMB
+tags: [talk]
+supporters:
+ - denbi
+ - elixir
+author: erasche
+---
+
+We will present the work of the GGA in the past years at ISMB/ECCB 2019 in Basel, Switzerland.
+
+You can [view a copy of the presentation](https://docs.google.com/presentation/d/1hJyI1sbfxAzzgoJ5E4eHNicSbYzBDaVwTwfOlOLiV3c/edit#slide=id.g5d8be916d1_0_182) online.

--- a/annotation/events.md
+++ b/annotation/events.md
@@ -1,0 +1,6 @@
+---
+# You don't need to edit this file, it's empty on purpose.
+# Edit theme's home layout instead if you wanna make some changes
+# See: https://jekyllrb.com/docs/themes/#overriding-theme-defaults
+layout: event_list
+---

--- a/annotation/galaxy/gxevents.md
+++ b/annotation/galaxy/gxevents.md
@@ -1,0 +1,3 @@
+---
+layout: event_list-galaxy
+---

--- a/annotation/galaxy/gxnews.md
+++ b/annotation/galaxy/gxnews.md
@@ -1,0 +1,3 @@
+---
+layout: news_list-galaxy
+---

--- a/annotation/galaxy/index.md
+++ b/annotation/galaxy/index.md
@@ -1,0 +1,6 @@
+---
+layout: external-galaxy
+---
+
+
+{% include home_news_events-galaxy.html %}

--- a/annotation/galaxy/index.md
+++ b/annotation/galaxy/index.md
@@ -1,6 +1,15 @@
 ---
-layout: external-galaxy
+layout: subsite-galaxy
+subdomain: annotation
+gitter: galaxy-genome-annotation/Lobby
+site: annotation
 ---
 
+<br/>
 
-{% include home_news_events-galaxy.html %}
+Welcome to **Galaxy for Genome Annotation** -- a platform to annotate, curate, and publish genomic data
+
+<img src="https://galaxy-genome-annotation.github.io/gga-clean.png" height="200px" alt="GGA Logo"/>
+
+
+{% include home_news_events.html %}

--- a/annotation/index.md
+++ b/annotation/index.md
@@ -1,0 +1,9 @@
+---
+layout: home
+title: Genome Annotation
+---
+
+
+
+{% include home_news_events.html %}
+{% include home_done.html %}

--- a/annotation/news.md
+++ b/annotation/news.md
@@ -1,0 +1,5 @@
+---
+layout: news_list
+title: News
+---
+

--- a/annotation/people.md
+++ b/annotation/people.md
@@ -1,0 +1,4 @@
+---
+# intentionally blank. Please edit _data/people.yml
+layout: people
+---

--- a/annotation/publications.md
+++ b/annotation/publications.md
@@ -1,0 +1,7 @@
+---
+layout: default
+---
+
+# Our publications
+
+{% bibliography --file annotation %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -323,6 +323,30 @@ body.location-pasteur {
 }
 
 
+body.location-annotation {
+	.navbar {
+		background-color: green !important;
+		border: 0px !important;
+	}
+
+	.navbar .navbar-brand, .navbar .navbar-nav > li > a {
+		color: white !important;
+	}
+
+	.navbar .navbar-brand:hover, .navbar .navbar-brand:focus,
+	.navbar .navbar-nav > li > a:hover, .navbar .navbar-nav > li > a:focus {
+		color: #aaa !important;
+	}
+
+	.nav > li > a:hover, .nav > li > a:focus {
+		background-color: transparent !important;
+	}
+
+	.nav .open > a, .nav .open > a:hover, .nav .open > a:focus {
+		background-color: transparent !important;
+		color: white;
+	}
+}
 .tooltable {
     td:nth-child(1) {
         width: 15%;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -168,15 +168,6 @@ img {
 }
 
 
-.border-freiburg {
-	border-left: 5px solid #2c3143 !important;
-}
-.border-erasmusmc {
-	border-left: 5px solid #f17925 !important;
-}
-.border-deNBI, .border-denbi {
-	border-left: 5px solid rgb(0, 174, 236) !important;
-}
 @import "people";
 @import "404";
 @import "news";
@@ -222,6 +213,12 @@ img {
 }
 
 
+.border-freiburg {
+	border-left: 5px solid #2c3143 !important;
+}
+.border-deNBI, .border-denbi {
+	border-left: 5px solid rgb(0, 174, 236) !important;
+}
 body.location-freiburg {
 	.navbar {
 		background-color: #2c3143 !important;
@@ -247,6 +244,9 @@ body.location-freiburg {
 	}
 }
 
+.border-erasmusmc {
+	border-left: 5px solid #f17925 !important;
+}
 body.location-erasmusmc {
 	.navbar {
 		background-color: #f17925 !important;
@@ -272,6 +272,9 @@ body.location-erasmusmc {
 	}
 }
 
+.border-belgium{
+	border-left: 5px solid #1b2944 !important;
+}
 body.location-belgium {
 	.navbar {
 		background-color: #1b2944 !important;
@@ -323,6 +326,9 @@ body.location-pasteur {
 }
 
 
+.border-annotation {
+	border-left: 5px solid green !important;
+}
 body.location-annotation {
 	.navbar {
 		background-color: green !important;

--- a/index-annotation.md
+++ b/index-annotation.md
@@ -2,10 +2,14 @@
 layout: subsite-galaxy
 subdomain: annotation
 gitter: galaxy-genome-annotation/Lobby
+site: annotation
 ---
 
 Welcome to **Galaxy for Genome Annotation** -- a platform to annotate, curate, and publish genomic data
 
 <img src="https://galaxy-genome-annotation.github.io/gga-clean.png" height="200px" alt="GGA Logo"/>
+
+
+{% include home_news_events.html key=annotation %}
 
 *Coming soon*


### PR DESCRIPTION
I wanted to have custom events/news for the annotation group and easiest way seemed to be making it a full member site. It works OKish, but some rough edges to work out first.

![image](https://user-images.githubusercontent.com/458683/61722610-e1ec2900-ad6a-11e9-97b3-8cd536586cf7.png)
![image](https://user-images.githubusercontent.com/458683/61722627-e9abcd80-ad6a-11e9-9fa9-f9e71a50fdeb.png)
![image](https://user-images.githubusercontent.com/458683/61722645-f16b7200-ad6a-11e9-8b77-849820f74405.png)

TODOs:

- [ ] multiply mentioned authors
- [ ] the duplication between /annotation/ and /annotation/galaxy/ (already a problem too but we ignore it?)

maybe just give up and have duplicate header bar. That would save a bunch of dupliction. Nl does this already.

![image](https://user-images.githubusercontent.com/458683/61722910-69399c80-ad6b-11e9-9899-3c1eaddd230b.png)

We could consider doing the same
