### PR TITLE
remove policy from carousel on galaxy.eu

### DIFF
--- a/_includes/home_carousel.html
+++ b/_includes/home_carousel.html
@@ -1,7 +1,7 @@
 <div class="row" id="carousel-eu-container">
   <div class="col-sm-12" id="carousel-eu">
 
-     {% if page.layout != "galaxy" %}
+    {% if page.layout != "galaxy" %}
      {% include carousel_before.html pages=8 %}
     {% else %}
      {% include carousel_before.html pages=7 %}

--- a/_includes/home_carousel.html
+++ b/_includes/home_carousel.html
@@ -1,6 +1,12 @@
 <div class="row" id="carousel-eu-container">
   <div class="col-sm-12" id="carousel-eu">
+
+     {% if page.layout != "galaxy" %}
      {% include carousel_before.html pages=8 %}
+    {% else %}
+     {% include carousel_before.html pages=7 %}
+    {% endif %}
+
         {% include home_carousel_galaxy.html %}
         {% include home_carousel_tiaas.html %}
         {% include home_carousel_usegalaxy_eu.html %}
@@ -9,7 +15,9 @@
         {% include home_carousel_training.html %}
         <!-- {% include home_carousel_acknowledgments.html %} -->
         {% include home_carousel_downtime.html %}
-        {% include home_carousel_data_policy.html %}
+        {% if page.layout != "galaxy" %}
+           {% include home_carousel_data_policy.html %}
+        {% endif %}
         {% include home_carousel_admin.html %}
         {% include home_carousel_subdomains.html %}
      {% include carousel_after.html %}


### PR DESCRIPTION
As discussed during today's code day... We remove policy slide from galaxy iframe, while original galaxyproject.eu still has to contain it. So... this PR implements it.



Current look:
![image](https://user-images.githubusercontent.com/15801412/92258370-035c9580-eed7-11ea-9b73-3baef6378e29.png)


new better look, that has only 7 elements

![image](https://user-images.githubusercontent.com/15801412/92258967-5cc4c480-eed7-11ea-8351-3e139efacbc7.png)


