### PR TITLE
write author name even if it's not in the people list

### DIFF
--- a/_includes/author.html
+++ b/_includes/author.html
@@ -1,12 +1,16 @@
 {% if include.author %}
-{% for group in site.data.people %}
-{% for person in group[1] %}
-{% if person[0] == include.author %}
-By: <a href="/people/#{{ person[0] }}">
-    <img src="https://avatars.githubusercontent.com/{{ person[0] }}" style="height: 2em">
-    {{ person[1].name }}
-</a>
-{% endif %}
-{% endfor %}
-{% endfor %}
+    {% for group in site.data.people %}
+        {% for person in group[1] %}
+            {% if person[0] == include.author %}
+            {% assign isAuthorFound = true %}
+            By: <a href="/people/#{{ person[0] }}">
+                <img src="https://avatars.githubusercontent.com/{{ person[0] }}" style="height: 2em">
+                {{ person[1].name }}
+            </a>
+            {% endif %}
+        {% endfor %}
+    {% endfor %}
+    {% unless isAuthorFound %}
+    By: {{ include.author }}
+    {% endunless %}
 {% endif %}


### PR DESCRIPTION
A feature requested by @beatrizserrano. The reference to the [problem](https://github.com/usegalaxy-eu/website/pull/594#discussion_r580424804).

From now on, we will include the author, even he/she is not on the list.
examples:
![image](https://user-images.githubusercontent.com/15801412/108880098-9e266900-760a-11eb-96ab-73432f03404e.png)


![image](https://user-images.githubusercontent.com/15801412/108880040-8c44c600-760a-11eb-918d-e86fc0abe35c.png)

P.S. 

Am I the only one struggling to build this project?
It took me almost the whole day to build this from scratch. `make install` and `make run` doesn't work. I had to move Gemfile and install dependencies with bundle, also installed some additional stuff to conda itself. Not sure if it's my unique issue, I reinstalled website and miniconda a few times during my attempts. Anyway... I am glad, it finally works. For the next time, I'd better create a docker container :)
