### PR TITLE
separate incoming/passed events and sort them differently

### DIFF
--- a/_includes/event.html
+++ b/_includes/event.html
@@ -1,0 +1,32 @@
+<tr class="{% if key_length == 0 or site.team_sites[key].private_news == false or key == "galaxy" %}border-{{ post.site }}{% endif %}">
+  {% if key_length == 0 or site.team_sites[key].private_news == false or key == "galaxy" %}
+  <td>
+      <div>{{ site.team_sites[include.post.site].name }}</div>
+  </td>
+  {% endif %}
+  <td>
+    <h4>
+      {% if include.post.external %}
+        <a href="{{ include.post.external }}" target="_blank" rel="noopener">
+      {% else %}
+        <a href="{{ include.post.url }}">
+      {% endif %}
+      {{ include.post.title | escape }}
+      </a>
+      <span>{% include article_icons.html post=include.post %}</span>
+    </h4>
+    <div>{{ include.post.excerpt }}</div>
+  </td>
+  <td>
+  <span class="text-nowrap">{{ include.post.starts | date: include.date_format }}</span>
+  </td>
+  <td>
+  <span class="text-nowrap">{{ include.post.ends   | date: include.date_format }}</span>
+  </td>
+  <td>
+    {% if include.post.location.city %}
+    {{ include.post.location.city }},
+    {% endif %}
+    {{ include.post.location.country }}
+  </td>
+</tr>

--- a/_layouts/event_list.html
+++ b/_layouts/event_list.html
@@ -45,7 +45,7 @@ layout: default
 
     }
     {% for post in posts_descending %}
-        if (new Date(`{{ post.starts | date: "%-d %b %Y" }}`) <= today) {
+        if (new Date(`{{ post.ends | date: "%-d %b %Y" }}`) <= today) {
             div = `
                 {% include event.html post=post date_format=date_format %}
             `
@@ -54,7 +54,7 @@ layout: default
     {% endfor %}
 
     {% for post in posts_ascending %}
-          if (new Date(`{{ post.starts | date: "%-d %b %Y" }}`) >= today) {
+          if (new Date(`{{ post.ends | date: "%-d %b %Y" }}`) >= today) {
             div = `
                 {% include event.html post=post date_format=date_format %}
             `

--- a/_layouts/event_list.html
+++ b/_layouts/event_list.html
@@ -69,12 +69,21 @@ layout: default
 
 
 {% for i in (1..2) %}
-
-
+{% if i==1 %}
+<h3 class="text-center"><span class="label label-success">Incoming</span></h3>
+{% else %}
+<h3 class="text-center"><span class="label label-warning">Passed</span></h3>
+{% endif %}
 <section class="section-content">
   <div class="col-md-12">
-    <table class="table panel-default">
-      <thead>
+    <table class="table table-striped">
+      <thead
+              {% if i==1 %}
+              class="list-group-item-success"
+              {% else %}
+              class="list-group-item-warning"
+              {% endif %}
+      >
         <tr>
           {% if key_length == 0 or site.team_sites[key].private_news == false or key == "galaxy" %}
           <th>Site</th>
@@ -95,15 +104,6 @@ layout: default
     </table>
   </div>
 </section>
-<div class="alert
-{% if i==1 %}
-  alert-success" role="alert">
-  <div class="text-center">Incoming</div>
-{% else %}
-    alert-warning" role="alert">
-  <div class="text-center">Passed</div>
-{% endif %}
-</div>
 
 {% endfor %}
 

--- a/_layouts/event_list.html
+++ b/_layouts/event_list.html
@@ -72,7 +72,7 @@ layout: default
 {% if i==1 %}
 <h2 class="text-center"><span class="label label-success">Current & Upcoming</span></h2>
 {% else %}
-<h2 class="text-center"><span class="label label-warning">Passed</span></h2>
+<h2 class="text-center"><span class="label label-warning">Past</span></h2>
 {% endif %}
 <section class="section-content">
   <div class="col-md-12">

--- a/_layouts/event_list.html
+++ b/_layouts/event_list.html
@@ -70,9 +70,9 @@ layout: default
 
 {% for i in (1..2) %}
 {% if i==1 %}
-<h3 class="text-center"><span class="label label-success">Incoming</span></h3>
+<h2 class="text-center"><span class="label label-success">Current & Upcoming</span></h2>
 {% else %}
-<h3 class="text-center"><span class="label label-warning">Passed</span></h3>
+<h2 class="text-center"><span class="label label-warning">Passed</span></h2>
 {% endif %}
 <section class="section-content">
   <div class="col-md-12">

--- a/_layouts/event_list.html
+++ b/_layouts/event_list.html
@@ -19,18 +19,61 @@ layout: default
 </section>
 
 {% if key_length == 0 %}
-  {% assign posts = site.events | sort:"starts" | reverse %}
+  {% assign posts_descending = site.events | sort:"starts" | reverse %}
+  {% assign posts_ascending = site.events | sort:"starts" %}
 {% else %}
   {% if site.team_sites[key].private_news == false or key == "galaxy" %}
-    {% assign posts = site.events | sort:"starts" | reverse %}
+    {% assign posts_descending = site.events | sort:"starts" | reverse %}
+    {% assign posts_ascending = site.events | sort:"starts"  %}
   {% else %}
-    {% assign posts = site.events | where:'site', key | sort:"starts" | reverse %}
+    {% assign posts_descending = site.events | where:'site', key | sort:"starts" | reverse %}
+    {% assign posts_ascending = site.events | where:'site', key | sort:"starts" %}
   {% endif %}
 {% endif %}
 
+
+<script>
+  const load = () => {
+    let recent = $("#recent-events");
+    let passed = $("#passed-events");
+    let div;
+    let date;
+    let today = new Date();
+    // ignore time (at least for now)
+    today.setHours(0,0,0,0)
+    const createDiv = ()=>{
+
+    }
+    {% for post in posts_descending %}
+        if (new Date(`{{ post.starts | date: "%-d %b %Y" }}`) <= today) {
+            div = `
+                {% include event.html post=post date_format=date_format %}
+            `
+            passed.append(div)
+          }
+    {% endfor %}
+
+    {% for post in posts_ascending %}
+          if (new Date(`{{ post.starts | date: "%-d %b %Y" }}`) >= today) {
+            div = `
+                {% include event.html post=post date_format=date_format %}
+            `
+            recent.append(div)
+          }
+    {% endfor %}
+  }
+  window.onload = load;
+</script>
+
+
+
+
+{% for i in (1..2) %}
+
+
 <section class="section-content">
   <div class="col-md-12">
-    <table class="table table-striped">
+    <table class="table panel-default">
       <thead>
         <tr>
           {% if key_length == 0 or site.team_sites[key].private_news == false or key == "galaxy" %}
@@ -42,42 +85,28 @@ layout: default
           <th>Location</th>
         </tr>
       </thead>
-      <tbody>
-        {% for post in posts %}
-          <tr class="{% if key_length == 0 or site.team_sites[key].private_news == false or key == "galaxy" %}border-{{ post.site }}{% endif %}">
-            {% if key_length == 0 or site.team_sites[key].private_news == false or key == "galaxy" %}
-            <td>
-                <div>{{ site.team_sites[post.site].name }}</div>
-            </td>
-            {% endif %}
-            <td>
-              <h4>
-                {% if post.external %}
-                  <a href="{{ post.external }}" target="_blank" rel="noopener">
-                {% else %}
-                  <a href="{{ post.url }}">
-                {% endif %}
-                {{ post.title | escape }}
-                </a>
-                <span>{% include article_icons.html post=post %}</span>
-              </h4>
-              <div>{{ post.excerpt }}</div>
-            </td>
-            <td>
-            <span class="text-nowrap">{{ post.starts | date: date_format }}</span>
-            </td>
-            <td>
-            <span class="text-nowrap">{{ post.ends   | date: date_format }}</span>
-            </td>
-            <td>
-              {% if post.location.city %}
-              {{ post.location.city }},
+      <tbody
+              {% if i==1 %}
+              id="recent-events">
+              {% else %}
+              id="passed-events">
               {% endif %}
-              {{ post.location.country }}
-            </td>
-          </tr>
-        {% endfor %}
       </tbody>
     </table>
   </div>
 </section>
+<div class="alert
+{% if i==1 %}
+  alert-success" role="alert">
+  <div class="text-center">Incoming</div>
+{% else %}
+    alert-warning" role="alert">
+  <div class="text-center">Passed</div>
+{% endif %}
+</div>
+
+{% endfor %}
+
+
+
+


### PR DESCRIPTION
resolves https://github.com/usegalaxy-eu/website/issues/629

This PR separates events between, current/future and passed. Also I sort them differently (as suggested by @tnabtaf), in ascending and descending order.
Please DO NOT merge this PR just yet. I would really appreciate your feedback and a few suggestions. 

Thanks to @tnabtaf and @bgruening for the proposal

A few screenshots, please try it out if you have a bit of spare time, thanks.

![image](https://user-images.githubusercontent.com/15801412/114095146-c4a41900-98c5-11eb-8121-515f3a6b7102.png)
![image](https://user-images.githubusercontent.com/15801412/114095227-dab1d980-98c5-11eb-916f-46fc88660a73.png)
