### PR TITLE
Sort events on galaxy front page

### DIFF
--- a/_includes/widget_events.html
+++ b/_includes/widget_events.html
@@ -3,7 +3,7 @@
     {% if include.logo %}
     <img src="/assets/media/galaxy-eu.svg" style="padding: 0.5em; height: 5em;"/>
     {% endif %}
-    {% assign items1 = site.events | sort:"starts" | reverse %}
+    {% assign items1 = site.events | sort:"starts" %}
 
     {% if include.site and site.team_sites[include.site].private_news %}
     {% assign items = items1 | where:'site', include.site %}
@@ -19,7 +19,12 @@
     {% assign url_ext = 'plain.html' %}
     {% endif %}
 
-    {% for post in items limit:6 %}
+    {% capture currentDate %}{{ site.time | date: '%F' }}{% endcapture %}
+    {% assign events_counter = 0%}
+
+    {% for post in items %}
+     {% capture postDate %}{{ post.starts | date: '%F' }}{% endcapture %}
+     {% if postDate > currentDate %}
       {% assign date_format = site.minima.date_format | default: "%b %-d, %Y" %}
       {% if post.external %}
         {% assign url = post.external %}
@@ -41,6 +46,11 @@
           {{ post.title | escape }}
         </h4>
       </a>
+      {% assign events_counter = events_counter | plus:1 %}
+      {%  if events_counter == 6 %}
+         {% break %}
+      {% endif %}
+     {% endif %}
     {% endfor %}
   </div>
 </div>


### PR DESCRIPTION
This is initial implementation of sorting events on the main galaxy front-page, suggested by @beatrizserrano in https://github.com/usegalaxy-eu/website/pull/631#issuecomment-816518028

The events widget shows 6 upcoming events, not 6 newest. (It's more profitable to show events that will come next week, rather than in half a year)

It appears that Jekyll cannot get current time (`sites.time` [returns the time of compilation](https://jekyllrb.com/docs/variables/)), meaning that we either have to compile it everyday to update the list or I will use JS magic again... Otherwise, here's the current look:

(WARNING: with current implementation, it will show incoming events according to "time of complication", not the current time):

![image](https://user-images.githubusercontent.com/15801412/114435407-c8d57c80-9bcc-11eb-8554-e509c7bd27ec.png)
 

P.S.
We probably don't have to sort news, because we won't potentially have "future news", right? correct me, if I'm wrong.
