### PR TITLE
Add GitHub Action for image auto-optimization

### DIFF
--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -1,0 +1,56 @@
+# This Action will run in the following scenarios:
+# - on Pull Requests containing images (not including forks)
+# - on pushing of images to `master` (for forks)
+# - on demand (https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)
+# - at 11 PM every Sunday if anything gets missed with any of the above scenarios
+# For Pull Requests, the images are added to the PR.
+# For other scenarios, a new PR will be opened if any images are compressed.
+name: Compress images
+on:
+  pull_request:
+    paths:
+      - '**.jpg'
+      - '**.jpeg'
+      - '**.png'
+      - '**.webp'
+  push:
+    branches:
+      - master
+    paths:
+      - '**.jpg'
+      - '**.jpeg'
+      - '**.png'
+      - '**.webp'
+  workflow_dispatch:
+  schedule:
+    - cron: '00 23 * * 0'
+jobs:
+  build:
+    name: calibreapp/image-actions
+    runs-on: ubuntu-latest
+    # Only run on main repo on and PRs that match the main repo.
+    if: |
+      github.repository == 'usegalaxy-eu/website' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@v2
+      - name: Compress Images
+        id: calibre
+        uses: calibreapp/image-actions@main
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          # For non-Pull Requests, run in compressOnly mode and we'll PR after.
+          compressOnly: ${{ github.event_name != 'pull_request' }}
+      - name: Create Pull Request
+        # If it's not a Pull Request then commit any changes as a new PR.
+        if: |
+          github.event_name != 'pull_request' &&
+          steps.calibre.outputs.markdown != ''
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: Auto Compress Images
+          branch-suffix: timestamp
+          commit-message: Compress Images
+          body: ${{ steps.calibre.outputs.markdown }}


### PR DESCRIPTION
This should resolve #656

As per the documentation in [Image Actions](https://github.com/calibreapp/image-actions), this will run in the following scenarios:
- on Pull Requests containing images (not including forks)
- on pushing images to the default branch (for forks)
- [on-demand](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)
- at 11 PM every Sunday if anything gets missed with any of the above scenarios

For Pull Requests, the images are added to the PR.
For other scenarios, a new PR will be opened if any images are compressed.

Let's see how it works 😄 