### PR TITLE
Add GitHub Action to auto-update citations

### DIFF
--- a/.github/workflows/update-citations.yml
+++ b/.github/workflows/update-citations.yml
@@ -1,0 +1,31 @@
+name: Update Citations
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '00 23 * * 0'
+
+jobs:
+  update-citations:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          python -m pip install bibtexparser Pyzotero
+      - name: Run update script
+        run: python update_citations-eu.py
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+            commit-message: Update citations
+            title: Update Citations
+            body: |
+              This is an auto-generated PR with the updated `citations` of [Galaxy EU](https://usegalaxy.eu)
+            branch: update-citations
+            delete-branch: true


### PR DESCRIPTION
Similar to #665 but, in this case, for citations.

It was *partially* tested because the Action does not fail, but I think there are no new citations available, so the automated PR won't be created until the script actually generates changes (as it should be).

This one also will run every **Sunday at 11 PM UTC** and manually if necessary.