### PR TITLE
Fix empty tag button in news list

### DIFF
--- a/_includes/filterable_news_list.html
+++ b/_includes/filterable_news_list.html
@@ -62,8 +62,10 @@
                   <span class="date">
                     {{ post.date | date: date_format }}
                   </span>
+                  {% if site.team_sites[post.site].name %}
                   <a href="javascript:window.location.href=window.location.href.split('?')[0] + '?tag={{ site.team_sites[post.site].name }}'"
                   class="btn btn-success btn-xs tag-element" role="button">{{ site.team_sites[post.site].name }}</a>
+                  {% endif %}
                   {% include article_tags.html post=post exclude_icons=true %}
                 </div>
                 <div class="news-content">


### PR DESCRIPTION
I opened galaxy news list and found out that empty tag button is still there 0_o
That's weird and we're not supposed to have it on our website. This PR fixes this issue.

Before:
![image](https://user-images.githubusercontent.com/15801412/120499140-1ba70580-c3c0-11eb-964f-9361717d3ae6.png)


Now:
![image](https://user-images.githubusercontent.com/15801412/120499257-32e5f300-c3c0-11eb-9264-7c60b3665041.png)



