### PR TITLE
Fix typo in a metadata key, remove unused duplicate metadata value.

### DIFF
--- a/_events/2017-11-06-vice.md
+++ b/_events/2017-11-06-vice.md
@@ -7,11 +7,10 @@ ends: 2017-11-06
 organiser:
   name: ViCE
   email:
-location: Compute Center University of Freiburg, Germany
 location:
   name: Rechenzentrum Freiburg
   street: Hermann-Herder-Straße 10
-  postam: 79104
+  postal: 79104
   city: Freiburg im Breisgau
   region: Baden-Württemberg
   country: Germany


### PR DESCRIPTION
This event file had the `postal` key misspelled as `postam`. It also had two entries for the `location` key: a string and a structured value. The string was being overridden.