### PR TITLE
Correct an instance where `state` was incorrectly used in a `location` field.

### DIFF
--- a/_events/2018-06-26-GCC.md
+++ b/_events/2018-06-26-GCC.md
@@ -9,7 +9,7 @@ organiser:
   email: contact@galaxyproject.org
 location:
   city: Portland
-  state: Oregon
+  region: Oregon
   country: USA
 
 ---


### PR DESCRIPTION
I believe `region` is the correct field.