### PR TITLE
Rectify GitHub account for José

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -76,7 +76,7 @@ freiburg:
         researchgate: Paul-Zierep
         bio:
 
-    josedominguez:
+    kysrpex:
         name: José Manuel Domínguez
         title: M.Sc. Math., Researcher
         email: dominguj@informatik.uni-freiburg.de


### PR DESCRIPTION
I did not realize that the top-level key for each person is supposed to be the GitHub account. Fixed.