### PR TITLE
Fix citation without publication year

### DIFF
--- a/_bibliography/citations-eu.bib
+++ b/_bibliography/citations-eu.bib
@@ -4574,7 +4574,8 @@ Subject\_term\_id: acute-myeloid-leukaemia;cancer-epigenetics;methylation-analys
  keywords = {{\textgreater}UseGalaxy.eu},
  title = {{IJMS} {\textbar} {Free} {Full}-{Text} {\textbar} {Meta}-{Analysis} of {Mechano}-{Sensitive} {Ion} {Channels} in {Human} {Hearts}: {Chamber}- and {Disease}-{Preferential} {mRNA} {Expression}},
  url = {https://www.mdpi.com/1422-0067/24/13/10961},
- urldate = {2023-07-05}
+ urldate = {2023-07-05},
+ year = {2023}
 }
 
 @article{nuhrenberg_impact_2022,


### PR DESCRIPTION
This is just a temporary fix, because the automation will attempt to remove the year. Be careful not to merge the next PR until somebody has fixed the [Zotero item](https://www.zotero.org/groups/1732893/galaxy/items/XY2VS7UP).