### PR TITLE
Enable mastodon in footer and remove galaxyproject twitter handle

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,8 +18,9 @@ description: The European Galaxy Instance
 email: contact@usegalaxy.eu
 baseurl: "/" # the subpath of your site, e.g. /blog
 url: "https://galaxyproject.eu" # the base hostname & protocol for your site, e.g. https://example.com
-twitter_username: galaxyproject
-github_username:  usegalaxy-eu
+mastodon_server: "bawü.social"
+mastodon_username: "galaxyfreiburg"
+github_username: usegalaxy-eu
 blurb:
     UseGalaxy.eu is maintained largely by the [Freiburg Galaxy
     Team](/freiburg/) but also collectively by groups and individuals from across
@@ -68,7 +69,8 @@ team_sites:
       name: Freiburg
       url: /freiburg/
       email: contact@usegalaxy.eu
-      twitter_username: galaxyproject
+      mastodon_server: "bawü.social"
+      mastodon_username: "galaxyfreiburg"
       github_username: usegalaxy-eu
       private_news: true
       url: "https://usegalaxy.eu/freiburg/"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -45,6 +45,9 @@
                     {% if lsite.twitter_username %}
                       <li><i class="fa fa-twitter"></i><a href="https://twitter.com/{{ lsite.twitter_username }}">{{ lsite.twitter_username }}</a></li>
                     {% endif %}
+                    {% if lsite.mastodon_username %}
+                      <li><img class="fa-mastodon" src="/assets/media/mastodon.svg" style="width:18px;height:18px;padding-right:4px;filter:grayscale(100%);-webkit-filter:grayscale(100%);"/><a href="https://{{ lsite.mastodon_server }}/@{{ lsite.mastodon_username }}">{{ lsite.mastodon_username }}</a></li>
+                    {% endif %}
                       <li><i class="fa fa-rss"></i>Subscribe <a href="/feed.xml">via RSS (UseGalaxy.eu Feed)</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
Twitter handles for sites other than Freiburg will be preserved.