### PR TITLE
EuroScienceGateway General Assembly Meeting 2024.md

### DIFF
--- a/_events/2022-04-28-Galaxy-Community-Call.md
+++ b/_events/2022-04-28-Galaxy-Community-Call.md
@@ -1,0 +1,13 @@
+---
+site: [pasteur, freiburg, erasmusmc, elixir-it, belgium, genouest]
+tags: 
+title: "Galaxy Community Call: The new History"
+starts: 2022-04-28
+ends: 2022-04-28
+organiser: Aysam Guerler, Marius van der Beek, Beatriz Serrano-Solano
+location: online
+supporters:
+external: "https://galaxyproject.org/events/2022-04-28-community-call/"
+---
+
+There will be a presentation of the new Galaxy History by Aysam Guerler, followed by a discussion and community updates.


### PR DESCRIPTION
---
site: Berlin
tags: meeting, General Assembly
title: "EuroScienceGateway General Assembly Meeting 2024"
starts: 2024-10-24
ends: 2024-10-24
organiser: ALU Freiburg Team
location:  ParkInn Hotel, Alexanderplatz 7, 10178, Berlin
supporters: EU
external: 
---

The annual meeting of the European project EuroScienceGateway, where representatives of each Consortium partner meet to take strategic decisions. 