### PR TITLE
corrected the f-string in the update tools script.

### DIFF
--- a/update_tools.py
+++ b/update_tools.py
@@ -27,7 +27,7 @@ for section in r.json():
     else:
         anchor = section['text'].replace(' ', '').lower()
         out += '<hr/>'
-        out += f'<h2 id="{anchor}">%s</h2>\n'
+        out += f'\n<hr/><h2 id="{anchor}">{section["text"]}</h2>\n\n'
 
 blurb = f"""---
 layout: default

--- a/update_tools.py
+++ b/update_tools.py
@@ -27,7 +27,7 @@ for section in r.json():
     else:
         anchor = section['text'].replace(' ', '').lower()
         out += '<hr/>'
-        out += f'\n<hr/><h2 id="{anchor}">{section["text"]}</h2>\n\n'
+        out += f'<h2 id="{anchor}">{section["text"]}</h2>\n\n'
 
 blurb = f"""---
 layout: default

--- a/update_tools.py
+++ b/update_tools.py
@@ -27,7 +27,7 @@ for section in r.json():
     else:
         anchor = section['text'].replace(' ', '').lower()
         out += '<hr/>'
-        out += f'<h2 id="{anchor}">{section["text"]}</h2>\n\n'
+        out += f'<h2 id="{anchor}">{section["text"]}</h2>\n'
 
 blurb = f"""---
 layout: default


### PR DESCRIPTION
It was previously discussed here: https://github.com/usegalaxy-eu/website/pull/1377
@bgruening  suggested to correct the python code instead of the html file. I am not sure how this may affect the weekly updated tools post.

What has changed?
- Swap the unused `%s` placeholder in the f-string for the actual `section["text"]` so the headings render properly.
- Added an `<hr/>` (with surrounding newlines) to insert a clear divider between sections.