### PR TITLE
Fix missing quotes in Matrix contact info for Jan

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -194,7 +194,7 @@ freiburg:
         website: http://leendertse.eu
         linkedin: JanLeendertse
         researchgate: JanLeendertse
-        matrix: @janleendertse:matrix.org
+        matrix: "@janleendertse:matrix.org"
 
     # beatrizserrano:
         # name: Beatriz Serrano-Solano


### PR DESCRIPTION
The lack of quotes is failing the website build CI, see https://build.galaxyproject.eu/job/usegalaxy-eu/job/website/5953/.