### PR TITLE
Add a deprecation banner pointing to the Galaxy Hub

### DIFF
--- a/_includes/deprecation-banner.html
+++ b/_includes/deprecation-banner.html
@@ -1,0 +1,56 @@
+<!--
+  Site-wide deprecation notice. usegalaxy.eu website content has migrated to the
+  Galaxy Hub (galaxyproject.org). This site stays online for continuity but every
+  page carries this banner directing visitors to the new home.
+
+  Included from _layouts/default.html, _layouts/default-galaxy.html and
+  _layouts/home.html so it appears on every rendered page. Not included in
+  widget.html (iframe embeds) or the .ics feed layouts.
+-->
+<div class="eu-deprecation-banner" role="region" aria-label="Site migration notice">
+  <div class="eu-deprecation-banner__inner">
+    <span class="eu-deprecation-banner__icon" aria-hidden="true">&#9888;</span>
+    <p class="eu-deprecation-banner__text">
+      This site has moved. UseGalaxy.eu pages now live on the
+      <strong>Galaxy Hub</strong>. This copy is kept for reference and is no longer updated.
+    </p>
+    <a class="eu-deprecation-banner__cta" href="https://galaxyproject.org/eu/">
+      Go to the new site &rarr;
+    </a>
+  </div>
+</div>
+
+<style>
+  .eu-deprecation-banner {
+    background: #2c3143;
+    border-bottom: 4px solid #ffd700;
+    color: #fff;
+    font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+  }
+  .eu-deprecation-banner__inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0.6rem 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+  .eu-deprecation-banner__icon { color: #ffd700; font-size: 1.1rem; line-height: 1; }
+  .eu-deprecation-banner__text { margin: 0; flex: 1 1 260px; font-size: 0.92rem; line-height: 1.4; }
+  .eu-deprecation-banner__cta {
+    flex: 0 0 auto;
+    background: #ffd700;
+    color: #2c3143;
+    font-weight: 700;
+    text-decoration: none;
+    padding: 0.4rem 0.9rem;
+    border-radius: 6px;
+    white-space: nowrap;
+  }
+  .eu-deprecation-banner__cta:hover { background: #e6c200; color: #2c3143; }
+  @media (max-width: 600px) {
+    .eu-deprecation-banner__inner { padding: 0.55rem 0.85rem; }
+    .eu-deprecation-banner__text { font-size: 0.87rem; }
+  }
+</style>

--- a/_layouts/default-galaxy.html
+++ b/_layouts/default-galaxy.html
@@ -2,6 +2,7 @@
 <html lang="{{ page.lang | default: site.lang | default: "en" }}">
   {% include head.html %}
   <body>
+    {% include deprecation-banner.html %}
     <div id="wrap">
       <div id="main">
         <div class="container" id="maincontainer">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,6 +7,7 @@
     {% assign key_length = key | size %}
 
   <body class="{% if key_length != 0 %}location-{{ key }}{% endif %}">
+    {% include deprecation-banner.html %}
     <div id="wrap">
       <div id="main">
         {% include header.html %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -7,6 +7,7 @@
     {% assign key_length = key | size %}
 
   <body class="{% if key_length != 0 %}location-{{ key }}{% endif %}">
+    {% include deprecation-banner.html %}
     <div id="wrap">
       <div id="main">
         {% include header.html %}


### PR DESCRIPTION
Adds a site-wide deprecation banner to the Jekyll site.

The usegalaxy.eu website content has migrated to the Galaxy Hub (galaxyproject.org). Rather than take this site down, we're keeping it online for continuity and adding a banner on every page that tells visitors it has moved and links to the new home at https://galaxyproject.org/eu/.

- New include `_includes/deprecation-banner.html`, pulled in by the three parent layouts (`default`, `default-galaxy`, `home`) so it shows on every rendered page.
- Left out of `widget.html` (iframe embeds) and the `.ics` feed layouts on purpose.
- Galaxy brand colours (dark `#2c3143`, gold `#ffd700`), responsive, no JavaScript.

Companion to the redirect work in usegalaxy-eu/infrastructure-playbook#2198 — migrated URLs 301 to the hub, and anything not individually mapped falls back to this banner-carrying site. Part of usegalaxy-eu/issues#943.
