### PR TITLE
Add a deprecation notice to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,24 @@
 # UseGalaxy.eu Page
 
+> [!IMPORTANT]
+> **This website is deprecated.** Its content has migrated to the
+> [Galaxy Hub](https://github.com/galaxyproject/galaxy-hub/). This repository is kept online
+> for continuity and reference, and is **no longer actively maintained** —
+> please make new content changes on the Galaxy Hub instead.
+>
+> ➡️ **Visit the new site: <https://galaxyproject.org/eu/>**
+
 ## Fancy Redirects
 
 Much content was moved around (in the output site) recently. That is because we're doing a strange and cool hybrid-site approach.
 
-Page       | Use
----------- | ---
-/          | main galaxy instance
-/about/    | About our galaxy instance
-/freiburg/ | About the freiburg team
-/news/     | news posts
-/events/   | events posts
+| Page       | Use                       |
+| ---------- | ------------------------- |
+| /          | main galaxy instance      |
+| /about/    | About our galaxy instance |
+| /freiburg/ | About the freiburg team   |
+| /news/     | news posts                |
+| /events/   | events posts              |
 
 We'll be doing some fancy proxying to accomplish this. The above mentioned
 pages (other than /) will have the full "chrome", i.e. top bar with
@@ -24,27 +32,25 @@ This is a terrible explanation but basically:
 - the site should be fully functional at usegalaxy-eu.github.io. This site can be referenced in communication materials.
 - certain important subpages (/freiburg/, /news/, /events/) will be available from usegalaxy.eu/.../ in order to tie those to our galaxy instance more closely.
 
-
 ## Server Maintenance
 
 If you need to register a notice event, edit `_data/notices.yml`. When
 the event is over, you should comment out that file.
 
-
 ## Duplication
 
 You will notice there is some duplication in the templates:
 
-Parent                            | Duplicate
----------------                   | --------------
-`_layout/event.html`              | `_layout/event-galaxy.html`
-`_layout/event_list.html`         | `_layout/event_list-galaxy.html`
-`_layout/news.html`               | `_layout/news-galaxy.html`
-`_layout/news_list.html`          | `_layout/news_list-galaxy.html`
-`_layout/news.md`                 | `_layout/gxnews.md`
-`_layout/events.md`               | `_layout/gxevents.md`
-`_layout/default.md`              | `_layout/default-galaxy.md`
-`_includes/home_news_events.html` | `_includes/home_news_events-galaxy.html`
+| Parent                            | Duplicate                                |
+| --------------------------------- | ---------------------------------------- |
+| `_layout/event.html`              | `_layout/event-galaxy.html`              |
+| `_layout/event_list.html`         | `_layout/event_list-galaxy.html`         |
+| `_layout/news.html`               | `_layout/news-galaxy.html`               |
+| `_layout/news_list.html`          | `_layout/news_list-galaxy.html`          |
+| `_layout/news.md`                 | `_layout/gxnews.md`                      |
+| `_layout/events.md`               | `_layout/gxevents.md`                    |
+| `_layout/default.md`              | `_layout/default-galaxy.md`              |
+| `_includes/home_news_events.html` | `_includes/home_news_events-galaxy.html` |
 
 This duplication is intentional, it is part of the `collections` configuration
 and allows us to produce "two" sites from one set of source documents. This is
@@ -60,7 +66,6 @@ the template they are inheriting from. The only major differences is that the
 normal templates read `for post in site.posts` (or `site.events`) while the
 galaxy templates read `for post in site.posts_plain` (`or site.events_plain`)
 
-
 ## Adding Posts
 
 These are used for tool notices / other server notices. Run:
@@ -70,7 +75,6 @@ bundle exec jekyll post "My new post"
 ```
 
 The only required metadata are tags and title, you should **remove layout** as that is inherited / specified automatically. If you put `tools` in the tags a wrench icon will show with the post.
-
 
 ## Adding Events
 
@@ -139,7 +143,6 @@ add events to get more exposure, you can add your funding agencies, own blog pos
 team and publications. To add your side please see this
 [example pull- request](https://github.com/usegalaxy-eu/website/pull/405).
 
-
 ## Building
 
 This website is jekyll based and can be build as every other jekyll page.
@@ -154,11 +157,11 @@ make run
 
 ## Deploying
 
-Our Jenkins bot deploy the website using 
+Our Jenkins bot deploy the website using
 
 ```console
 make install
 make build
 ```
-and the script `.deploy.sh`.
 
+and the script `.deploy.sh`.


### PR DESCRIPTION
Adds a deprecation notice to the top of the README.

The usegalaxy.eu website content has migrated to the Galaxy Hub. Anyone landing on this repository should know it's no longer the place to make content changes and be pointed to the new home. This adds a `> [!IMPORTANT]` notice at the top that:

- states the site is deprecated and content has moved to https://galaxyproject.org/eu/,
- notes the repo is kept online for continuity but no longer actively maintained,
- links the redirect map (usegalaxy-eu/infrastructure-playbook#2198) and the deprecation banner (#1504).

Companion to the banner PR #1504. Part of usegalaxy-eu/issues#943.
